### PR TITLE
Add visa sponsorship question

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -11,6 +11,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import 'patterns/simplemde-theme';
 @import 'patterns/success-summary';
 @import "patterns/destructive-button";
+@import "components/list";
 @import "components/map";
 @import "components/notification-banner";
 @import "components/application-card";
@@ -130,10 +131,6 @@ table thead th {
 dt,
 dd {
   display: inline;
-}
-
-dt {
-  margin-right: 0.25em;
 }
 
 dl.aligned {

--- a/app/assets/sass/components/_list.scss
+++ b/app/assets/sass/components/_list.scss
@@ -1,0 +1,72 @@
+%app-list--description {
+  @include govuk-clearfix;
+  margin-top: 0;
+}
+
+%app-list--description > dt {
+  @include govuk-font($size: 19, $weight: bold);
+  vertical-align: top;
+
+  @include mq ($from: desktop) {
+    clear: left;
+    float: left;
+    margin-bottom: govuk-spacing(1);
+    width: 30%;
+  }
+}
+
+%app-list--description > dd {
+  @include govuk-font($size: 19, $weight: normal);
+  margin: 0 0 govuk-spacing(2) 0;
+  vertical-align: top;
+
+  @include mq ($from: desktop) {
+    float: left;
+    margin-bottom: govuk-spacing(1);
+    width: 70%;
+  }
+
+  .govuk-details,
+  .govuk-details__summary {
+    margin-bottom: 0;
+  }
+
+  .govuk-details__text {
+    margin-bottom: govuk-spacing(2);
+  }
+}
+
+.app-list--description {
+  @extend %app-list--description;
+
+  &__label:after {
+    display: inline-block;
+  }
+
+  &__hint {
+    @include govuk-font($size: 16, $weight: normal);
+    color: $govuk-secondary-text-colour;
+    display: block;
+    margin-bottom: govuk-space(1);
+  }
+}
+
+.app-list--dash {
+  padding-left: govuk-spacing(3);
+
+  li {
+    position: relative;
+
+    &:before {
+      color: govuk-colour("dark-grey");
+      content: "\2013";
+      left: -16px;
+      position: absolute;
+      top: 0;
+    }
+  }
+}
+
+.app-list--locations {
+  columns: 3 8em;
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -469,7 +469,7 @@ router.post('/course/:providerCode/:code', function (req, res) {
 
   data[c.programmeCode + '-publish-state'] = state
 
-  res.render('course', {
+  res.render('course/index', {
     course: c,
     errors: validate(data, c),
     publishState: state,
@@ -530,11 +530,12 @@ router.get('/preview/:providerCode/:code', function (req, res) {
 })
 
 router.get('/course/:providerCode/:code/:view', function (req, res) {
-  const view = req.params.view
+  const {code, view } = req.params
   const c = course(req)
 
   res.render(`course/${view}`, {
     course: c,
+    code: code,
     errors: validate(req.session.data, c, view)
   })
 })

--- a/app/views/course/visa-sponsorship.html
+++ b/app/views/course/visa-sponsorship.html
@@ -1,0 +1,51 @@
+{% extends "layout.html" %}
+{% set title = "Visa sponsorship" %}
+{% set backLink = course.path %}
+
+{% block beforeContent %}
+  {{ govukBackLink({href: course.path + "#information"})}}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form action="{{ course.path + "#information" }}" method="post">
+
+        {% set radioName = code + "-visa-sponsorship" %}
+
+        {% set courseType = data[code + "-type"] %}
+
+        {% if courseType === "Salaried" %}
+          {% set questionText = "Can you sponsor a Skilled worker visa?" %}
+        {% else %}
+          {% set questionText = "Can you sponsor a Student visa?" %}
+        {% endif %}
+
+        {{ govukRadios({
+          name: radioName,
+          fieldset: {
+            legend: {
+              text: questionText,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes"
+            },
+            {
+              value: "No",
+              text: "No"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({text: "Continue"}) }}
+
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/course/visa-sponsorship.html
+++ b/app/views/course/visa-sponsorship.html
@@ -9,6 +9,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-xl">{{ course.name | safe }} ({{ course.programmeCode }})</span>
 
       <form action="{{ course.path + "#information" }}" method="post">
 

--- a/app/views/course/visa-sponsorship.html
+++ b/app/views/course/visa-sponsorship.html
@@ -35,11 +35,13 @@
           items: [
             {
               value: "Yes",
-              text: "Yes"
+              text: "Yes",
+              checked: (data[radioName] === "Yes")
             },
             {
               value: "No",
-              text: "No"
+              text: "No",
+              checked: (data[radioName] === "No")
             }
           ]
         }) }}

--- a/app/views/new/_answers.html
+++ b/app/views/new/_answers.html
@@ -175,6 +175,34 @@
   </dd>
   {% endif %}
 </div>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Visa sponsorship
+  </dt>
+  <dd class="govuk-summary-list__value">
+    {% set courseType = data[code + "-type"] %}
+    {% set visaSponsorship = data[code + '-visa-sponsorship'] %}
+
+    {% if visaSponsorship === "Yes" %}
+      {% if courseType === "Salaried" %}
+        You can sponsor a Skilled worker visa
+      {% else %}
+        You can sponsor a Student visa
+      {% endif %}
+    {% elseif visaSponsorship === "No" %}
+      You cannot sponsor a visa
+    {% endif %}
+  </dd>
+  {% if showChangeLinks %}
+  <dd class="govuk-summary-list__actions">
+    <a href="{{ course.path + "/visa-sponsorship" }}">
+      Change<span class="govuk-visually-hidden"> visa sponsorship</span>
+    </a>
+  </dd>
+  {% endif %}
+</div>
+
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key">
     Locations

--- a/app/views/preview.html
+++ b/app/views/preview.html
@@ -9,14 +9,14 @@
   </div>
 
   <h1 class="govuk-heading-xl">
-    <span class="govuk-!-font-size-36">{{ data['training-provider-name'] }}</span><br />
+    <span class="govuk-heading-l govuk-!-margin-bottom-1">{{ data['training-provider-name'] }}</span>
     {{ course.name }} ({{ course.programmeCode }})
   </h1>
 
   <p class="govuk-body-l">{{ course.options[0] }}</p>
 
-  <dl class="aligned">
-    <dt>Qualification:</dt>
+  <dl class="app-list--description govuk-!-margin-bottom-8">
+    <dt>Qualification</dt>
     <dd>
       <details class="govuk-details">
         {% if 'PGCE' in course.options[0] %}
@@ -38,7 +38,7 @@
         {% endif %}
       </details>
     </dd>
-    <dt>Course length:</dt>
+    <dt>Course length</dt>
     <dd>
       {% if data[prefix + '-duration'] == 'Other' %}
         {{ data[prefix + '-duration-other'] }}
@@ -46,9 +46,9 @@
         {{ data[prefix + '-duration'] or '1 year' }}
       {% endif %}
     </dd>
-    <dt>Date you can apply from:</dt>
+    <dt>Date you can apply from</dt>
     <dd>26 October 2018</dd>
-    <dt>Website:</dt>
+    <dt>Website</dt>
     <dd>
       {% if (data[subject.slug + '-' + accrediting.slug + '-course-website']) %}
         <a href="{{ data[subject.slug + '-' + accrediting.slug + '-course-website'] }}">{{ data[subject.slug + '-' + accrediting.slug + '-course-website'] }}</a>
@@ -68,20 +68,21 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="course-contents">
         <h2 class="govuk-heading-m">Contents</h2>
-        <ul class="govuk-list">
+        <ul class="govuk-list app-list--dash">
           <li><a href="#section-about">About the course</a></li>
+          <li><a href="#section-schools">School placements</a></li>
+          <li><a href="#section-entry">Entry requirements</a></li>
+          <li><a href="#section-about-provider">About the training provider</a></li>
+          {% if course.salaried %}
+            <li><a href="#section-salary">Salary</a></li>
+          {% endif %}
           {% if data[prefix + '-interview-process'] %}
             <li><a href="#section-interview">Interview process</a></li>
           {% endif %}
-          <li><a href="#section-schools">How school placements work</a></li>
           {% if course.salaried %}
             <li><a href="#section-salary">Salary</a></li>
-          {% else %}
-            <li><a href="#section-fees">Fees</a></li>
           {% endif %}
-          <li><a href="#section-financial-support">Financial support</a></li>
-          <li><a href="#section-entry">Requirements</a></li>
-          <li><a href="#section-about-provider">About the training provider</a></li>
+          <li><a href="#section-fees">Fees and financial support</a></li>
           <li><a href="#section-access-needs">Training with disabilities and other needs</a></li>
           <li><a href="#section-contact">Contact details</a></li>
           <li><a href="#section-apply">Apply</a></li>

--- a/app/views/preview.html
+++ b/app/views/preview.html
@@ -182,9 +182,9 @@
         <p class="govuk-body">
           {% if visaSponsorship === "Yes" %}
             {% if courseType === "Salaried" %}
-              We are able to sponsor a Skilled worker visa, however this is not guaranteed.
+              We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Skilled worker visas</a>, but this is not guaranteed.
             {% else %}
-              We are able to sponsor a Student visa, however this is not guaranteed.
+              We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Student visas</a>, but this is not guaranteed.
             {% endif %}
           {% elseif visaSponsorship === "No" %}
 

--- a/app/views/preview.html
+++ b/app/views/preview.html
@@ -83,7 +83,7 @@
           {% if data[prefix + '-interview-process'] %}
             <li><a href="#section-interview">Interview process</a></li>
           {% endif %}
-          <li><a href="#section-international">International candidates</a></li>
+          <li><a href="#section-international">International students</a></li>
           <li><a href="#section-access-needs">Training with disabilities and other needs</a></li>
           <li><a href="#section-contact">Contact details</a></li>
           <li><a href="#section-apply">Apply</a></li>
@@ -174,7 +174,7 @@
           {{ macros.previewPart(prefix + '-interview-process') }}
         {% endif %}
 
-        <h2 class="govuk-heading-l" id="section-international">International candidates</h2>
+        <h2 class="govuk-heading-l" id="section-international">International students</h2>
 
         {% set courseType = data[prefix + "-type"] %}
         {% set visaSponsorship = data[prefix + '-visa-sponsorship'] %}

--- a/app/views/preview.html
+++ b/app/views/preview.html
@@ -76,13 +76,14 @@
           {% if course.salaried %}
             <li><a href="#section-salary">Salary</a></li>
           {% endif %}
-          {% if data[prefix + '-interview-process'] %}
-            <li><a href="#section-interview">Interview process</a></li>
-          {% endif %}
           {% if course.salaried %}
             <li><a href="#section-salary">Salary</a></li>
           {% endif %}
           <li><a href="#section-fees">Fees and financial support</a></li>
+          {% if data[prefix + '-interview-process'] %}
+            <li><a href="#section-interview">Interview process</a></li>
+          {% endif %}
+          <li><a href="#section-international">International candidates</a></li>
           <li><a href="#section-access-needs">Training with disabilities and other needs</a></li>
           <li><a href="#section-contact">Contact details</a></li>
           <li><a href="#section-apply">Apply</a></li>
@@ -91,19 +92,39 @@
         <h2 class="govuk-heading-l" id="section-about">About the course</h2>
         {{ macros.previewPart(prefix + '-about-this-course') }}
 
-        {% if data[prefix + '-interview-process'] %}
-          <h2 class="govuk-heading-l" id="section-interview">Interview process</h2>
-          {{ macros.previewPart(prefix + '-interview-process') }}
+        <h2 class="govuk-heading-l" id="section-schools">School placements</h2>
+        {{ macros.previewPart(prefix + '-placement-school-policy') }}
+
+        <h2 class="govuk-heading-l" id="section-entry">Entry requirements</h2>
+
+        <h3 class="govuk-heading-m">Qualifications needed</h3>
+        {{ macros.previewPart(prefix + '-qualifications-required') }}
+
+        {% if data[prefix + '-personal-qualities'] %}
+          <h3 class="govuk-heading-m">Personal qualities</h3>
+          {{ macros.previewPart(prefix + '-personal-qualities') }}
         {% endif %}
 
-        <h2 class="govuk-heading-l" id="section-schools">How school placements work</h2>
-        {{ macros.previewPart(prefix + '-placement-school-policy') }}
+        {% if data[prefix + '-other-requirements'] %}
+          <h3 class="govuk-heading-m">Other requirements</h3>
+          {{ macros.previewPart(prefix + '-other-requirements') }}
+        {% endif %}
+
+        <h2 class="govuk-heading-l" id="section-about-provider">About the training provider</h2>
+        {{ macros.previewPart('about-organisation', true) }}
+
+        {% if not accrediting.selfAccrediting %}
+          {% if data[accrediting.slug + '-about-accrediting-provider'] %}
+            <h3 class="govuk-heading-m">About {{ accrediting.name }}</h3>
+            {{ macros.previewPart(accrediting.slug + '-about-accrediting-provider', true) }}
+          {% endif %}
+        {% endif %}
 
         {% if course.salaried %}
           <h2 class="govuk-heading-l" id="section-salary">Salary</h2>
           {{ macros.previewPart(prefix + '-salary-details') }}
         {% else %}
-          <h2 class="govuk-heading-l" id="section-fees">Fees</h2>
+          <h2 class="govuk-heading-l" id="section-fees">Fees and financial support</h2>
 
           {% if not data[prefix + '-fee'] %}
             {{ macros.previewPart(prefix + '-fee') }}
@@ -140,7 +161,6 @@
           {% endif %}
         {% endif %}
 
-        <h2 class="govuk-heading-l" id="section-financial-support">Financial support</h3>
         <p>You may be eligible for <a href="https://www.gov.uk/teacher-training-funding">financial support while you study, including bursaries, scholarships and loans</a>.</p>
         <p><a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates">Financial support if you’re from outside of the UK</a>.</p>
 
@@ -149,30 +169,36 @@
           {{ macros.previewPart(prefix + '-financial-support') }}
         {% endif %}
 
-        <h2 class="govuk-heading-l" id="section-entry">Requirements</h2>
-
-        <h3 class="govuk-heading-m">Qualifications needed</h3>
-        {{ macros.previewPart(prefix + '-qualifications-required') }}
-
-        {% if data[prefix + '-personal-qualities'] %}
-          <h3 class="govuk-heading-m">Personal qualities</h3>
-          {{ macros.previewPart(prefix + '-personal-qualities') }}
+        {% if data[prefix + '-interview-process'] %}
+          <h2 class="govuk-heading-l" id="section-interview">Interview process</h2>
+          {{ macros.previewPart(prefix + '-interview-process') }}
         {% endif %}
 
-        {% if data[prefix + '-other-requirements'] %}
-          <h3 class="govuk-heading-m">Other requirements</h3>
-          {{ macros.previewPart(prefix + '-other-requirements') }}
-        {% endif %}
+        <h2 class="govuk-heading-l" id="section-international">International candidates</h2>
 
-        <h2 class="govuk-heading-l" id="section-about-provider">About the training provider</h2>
-        {{ macros.previewPart('about-organisation', true) }}
+        {% set courseType = data[prefix + "-type"] %}
+        {% set visaSponsorship = data[prefix + '-visa-sponsorship'] %}
 
-        {% if not accrediting.selfAccrediting %}
-          {% if data[accrediting.slug + '-about-accrediting-provider'] %}
-            <h3 class="govuk-heading-m">About {{ accrediting.name }}</h3>
-            {{ macros.previewPart(accrediting.slug + '-about-accrediting-provider', true) }}
+        <p class="govuk-body">
+          {% if visaSponsorship === "Yes" %}
+            {% if courseType === "Salaried" %}
+              We are able to sponsor a Skilled worker visa, however this is not guaranteed.
+            {% else %}
+              We are able to sponsor a Student visa, however this is not guaranteed.
+            {% endif %}
+          {% elseif visaSponsorship === "No" %}
+
+            We are unable to sponsor a visa.
+            You will need to <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">get the right visa or status to {{"work" if  courseType == "Salaried" else "study" }} in the UK</a>.
           {% endif %}
-        {% endif %}
+        </p>
+
+        <p class="govuk-body">
+          You do not need a visa if you already have settled or pre-settled status under the EU Settlement Scheme, or if you are an Irish citizen.
+        </p>
+
+        <p class="govuk-body">Candidates with qualifications from non-UK institutions may need to provide evidence of comparability by applying for a <a href="https://www.enic.org.uk" class="govuk-link">UK ENIC statement</a>.</p>
+
 
         <h2 class="govuk-heading-l" id="section-access-needs">Training with disabilities and other needs</h2>
         {{ macros.previewPart('training-with-a-disability', true) }}


### PR DESCRIPTION
This adds an option for each course, to ask whether the provider can sponsor either a Skilled worker visa (for salaried courses) or a Student visa (for unsalaried courses). The answer given is summarised on the Basic details tab.

The preview of the page on Find has also been updated with a new "International students" section, which is populated with some text based upon the answer given to the Visa sponsorship question. Wording mostly taken from [Get into teaching](https://getintoteaching.education.gov.uk/international-candidates) and [GOV.UK](https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration) pages.

## Screenshots

### Can you sponsor a Student visa?
![can you sponsor a student visa](https://user-images.githubusercontent.com/30665/116095383-41920980-a6a0-11eb-94da-d40873395879.png)

### Can you sponsor a Skilled worker visa?
![can you sponsor a skilled worker visa](https://user-images.githubusercontent.com/30665/116095446-5373ac80-a6a0-11eb-8936-14fcfd39ec76.png)

### Basic details tab showing summary
![localhost_3000_course_2CH_2YMZ (6)](https://user-images.githubusercontent.com/30665/116095681-8a49c280-a6a0-11eb-9a47-dc4f63132138.png)

### International students section on preview page
<img width="704" alt="Screenshot 2021-04-26 at 16 56 47" src="https://user-images.githubusercontent.com/30665/116113445-69896900-a6b0-11eb-97ec-b9dbf0854e8a.png">
