### PR TITLE
EU students and home fee status eligibility

### DIFF
--- a/app/views/preview.html
+++ b/app/views/preview.html
@@ -130,6 +130,8 @@
             </div>
           {% endif %}
 
+          <p class="govuk-body">Some candidates, such as those with settled or pre-settled status under the EU Settlement scheme, may be <a href="https://www.gov.uk/government/publications/student-finance-eligibility-2021-to-2022-academic-year" class="govuk-body">eligible for home fee status and student finance</a>.</p>
+
           {% if data[prefix + '-fee-details'] %}
             {{ macros.previewPart(prefix + '-fee-details') }}
           {% endif %}

--- a/app/views/preview.html
+++ b/app/views/preview.html
@@ -119,10 +119,6 @@
                     <td class="govuk-table__cell">UK students</td>
                     <td class="govuk-table__cell">£{{ data[prefix + '-fee'] }}</td>
                   </tr>
-                  <tr class="govuk-table__row">
-                    <td class="govuk-table__cell">EU students</td>
-                    <td class="govuk-table__cell">£{{ data[prefix + '-fee'] }}</td>
-                  </tr>
                   {% if data[prefix + '-fee-international'] %}
                   <tr class="govuk-table__row">
                     <td class="govuk-table__cell">International students</td>


### PR DESCRIPTION
This updates the preview of the Find page to remove "EU students" as having the same fee as UK students, and instead link to a page on GOV.UK which described home fee eligibility.

## Screenshots

### Before
<img width="735" alt="Screenshot 2021-04-26 at 17 28 38" src="https://user-images.githubusercontent.com/30665/116118253-00f0bb00-a6b5-11eb-877b-62d7d6eb8fa4.png">

### After
<img width="836" alt="Screenshot 2021-04-26 at 17 26 33" src="https://user-images.githubusercontent.com/30665/116118293-09e18c80-a6b5-11eb-8755-4b6adbd0ffab.png">
