### PR TITLE
Rollover interstitial for 2021 to 2022

### DIFF
--- a/app/views/rolled-over.html
+++ b/app/views/rolled-over.html
@@ -1,22 +1,38 @@
 {% extends "layout.html" %}
-{% set title = "Begin preparing for the next cycle" %}
-{% set backLink = "/transition" %}
+{% set title = "Prepare for the next cycle" %}
+{% set backLink = "/" %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        Begin preparing for the next&nbsp;cycle
+        Prepare for the next cycle
       </h1>
 
-      <p>All your courses, locations and details have been rolled over from the current cycle. You can now update them for the next recruitment cycle&nbsp;(2020 to 2021).</p>
+      <p>All your courses, locations and details have been copied over.</p>
 
-      <p>You can:</p>
+      <p>Courses for the next cycle will be published on 1 September 2021.</p>
+
+      <p>Before then, you can:</p>
+
       <ul class="govuk-list govuk-list--bullet">
         <li>add new courses</li>
         <li>delete courses you’re no longer running</li>
-        <li>edit titles, outcomes and locations</li>
+        <li>edit details for your courses</li>
       </ul>
+
+      <h2 class="govuk-heading-m">New for 2021 to 2022</h2>
+
+      <p>Applications for all courses will be via Apply for teaching training, not UCAS.</p>
+
+      <p>For each course, you will need to confirm:</p>
+
+      <ol class="govuk-list govuk-list--number">
+        <li>degree requirements</li>
+        <li>GCSE requirements</li>
+        <li>visa sponsorship</li>
+        <li>locations of school placements</li>
+      </ol>
 
       <hr class="govuk-section-break govuk-section-break--m" />
 


### PR DESCRIPTION
Previous cycles used an interstitial page to introduce the rollover period. This updates the content for the next cycle.

## Screenshot

![localhost_3000_rolled-over (1)](https://user-images.githubusercontent.com/30665/117116927-d7a3ef00-ad86-11eb-8a4d-e6e1e4929e17.png)

