### PR TITLE
Sign in - rollover flow

### DIFF
--- a/app/views/cycles.html
+++ b/app/views/cycles.html
@@ -39,6 +39,10 @@
     </div>
     <div class="govuk-grid-column-one-third">
       <div class="status-box">
+        <h2 class="govuk-heading-m">Prepare for the next cycle</h2>
+        <p class="govuk-body">Courses for the next cycle will be published on 1&nbsp;September&nbsp;2021.</p>
+        <p class="govuk-body"><a href="/rolled-over" class="govuk-link">What you need to do</a></p>
+
         <h2 class="govuk-heading-m">Support and guidance</h2>
         <p class="govuk-body">If you have a question, or you’ve had a problem using Publish, you can email:</p>
         <p class="govuk-body govuk-!-margin-bottom-0">

--- a/app/views/cycles.html
+++ b/app/views/cycles.html
@@ -36,18 +36,6 @@
           <li>manage locations needed for the next cycle</li>
         </ul>
       </div>
-
-      <div class="govuk-!-margin-bottom-8">
-        <h2 class="govuk-heading-m">
-          <a href="/about-your-organisation">About your organisation</a>
-        </h2>
-        <p>Use this section to:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>write about your organisation</li>
-          <li>set your contact details</li>
-          <li>publish this information on all course pages</li>
-        </ul>
-      </div>
     </div>
     <div class="govuk-grid-column-one-third">
       <div class="status-box">

--- a/app/views/organisation/index.html
+++ b/app/views/organisation/index.html
@@ -40,17 +40,15 @@
         {% endif %}
       {% endif %}
 
-      {% if not (data["rolled-over"] and data["next-cycle"]) %}
-        <h2 class="govuk-heading-m">
-          <a href="/about-your-organisation">About your organisation</a>
-        </h2>
-        <p>Use this section to:</p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
-          <li>write about your organisation</li>
-          <li>set your contact details</li>
-          <li>publish this information on all course pages</li>
-        </ul>
-      {% endif %}
+      <h2 class="govuk-heading-m">
+        <a href="/about-your-organisation">About your organisation</a>
+      </h2>
+      <p>Use this section to:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
+        <li>write about your organisation</li>
+        <li>set your contact details</li>
+        <li>publish this information on all course pages</li>
+      </ul>
 
       <h2 class="govuk-heading-m">
         <a href="/courses">Courses</a>

--- a/app/views/rolled-over.html
+++ b/app/views/rolled-over.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% set title = "Prepare for the next cycle" %}
-{% set backLink = "/" %}
+{% set backLink = "/cycles" %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/views/sign-in.html
+++ b/app/views/sign-in.html
@@ -1,0 +1,30 @@
+{% extends "layout.html" %}
+{% set title = "Sign in to Publish teaching training" %}
+
+{% block header %}
+  {{ govukHeader({
+    homepageUrl: "/sign-in",
+    productName: serviceName,
+    containerClasses: "govuk-width-container",
+    navigationClasses: "govuk-header__navigation--end"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        {{ title }}
+      </h1>
+
+      <p class="govuk-body-m">Use DfE Sign-in to access your account.</p>
+
+      {{ govukButton({text: "Sign in using DfE Sign-in", href: "/rolled-over"}) }}
+
+      <p class="govuk-body-m">
+        If you do not have a DfE Sign-in account but need access to Publish teaching training email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.
+      </p>
+
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This sets up the prototype for some user testing around the rollover flow and updating courses.

* Adds a basic sign in page to start from (`/sign-in`) which links to interstitial page
* Moves the "About your organisation" section to be cycle-specific
* Links to interstitial page from cycle page (in case users want to refer back to it)
