### PR TITLE
Bugfix with prototype data

### DIFF
--- a/app/data/prototype-data.json
+++ b/app/data/prototype-data.json
@@ -58,7 +58,7 @@
     "Middleton Primary School"
   ],
   "2XT2-has-accredited-body": "Another organisation",
-  "2XT2-accredited-body": "Gorse Scitt",
+  "2XT2-accredited-body": "Gorse SCITT",
   "2XT2-vacancies-flag": "Yes",
   "2XT2-vacancies-choice": "There are some vacancies",
   "2XT2-full-time-and-part-time": false,
@@ -114,7 +114,7 @@
     "Boston Spa School"
   ],
   "238T-has-accredited-body": "Another organisation",
-  "238T-accredited-body": "Gorse Scitt",
+  "238T-accredited-body": "Gorse SCITT",
   "238T-vacancies-flag": "Yes",
   "238T-vacancies-choice": "There are some vacancies",
   "238T-full-time-and-part-time": false,
@@ -174,7 +174,7 @@
     "The Bruntcliffe Academy"
   ],
   "2392-has-accredited-body": "Another organisation",
-  "2392-accredited-body": "Gorse Scitt",
+  "2392-accredited-body": "Gorse SCITT",
   "2392-vacancies-flag": "Yes",
   "2392-vacancies-choice": "There are some vacancies",
   "2392-full-time-and-part-time": false,
@@ -231,7 +231,7 @@
     "Leeds West Academy"
   ],
   "2393-has-accredited-body": "Another organisation",
-  "2393-accredited-body": "Gorse Scitt",
+  "2393-accredited-body": "Gorse SCITT",
   "2393-vacancies-flag": "Yes",
   "2393-vacancies-choice": "There are some vacancies",
   "2393-full-time-and-part-time": false,
@@ -287,7 +287,7 @@
     "Boston Spa School"
   ],
   "2394-has-accredited-body": "Another organisation",
-  "2394-accredited-body": "Gorse Scitt",
+  "2394-accredited-body": "Gorse SCITT",
   "2394-vacancies-flag": "No",
   "2394-vacancies-choice": "There are no vacancies",
   "2394-full-time-and-part-time": false,
@@ -392,7 +392,7 @@
     "Leeds West Academy"
   ],
   "2395-has-accredited-body": "Another organisation",
-  "2395-accredited-body": "Gorse Scitt",
+  "2395-accredited-body": "Gorse SCITT",
   "2395-vacancies-flag": "Yes",
   "2395-vacancies-choice": "There are some vacancies",
   "2395-full-time-and-part-time": false,
@@ -437,7 +437,7 @@
     "Boston Spa School"
   ],
   "2396-has-accredited-body": "Another organisation",
-  "2396-accredited-body": "Gorse Scitt",
+  "2396-accredited-body": "Gorse SCITT",
   "2396-vacancies-flag": "Yes",
   "2396-vacancies-choice": "There are some vacancies",
   "2396-full-time-and-part-time": false,
@@ -480,7 +480,7 @@
     "Leeds West Academy"
   ],
   "2397-has-accredited-body": "Another organisation",
-  "2397-accredited-body": "Gorse Scitt",
+  "2397-accredited-body": "Gorse SCITT",
   "2397-vacancies-flag": "Yes",
   "2397-vacancies-choice": "There are some vacancies",
   "2397-full-time-and-part-time": false,
@@ -526,7 +526,7 @@
     "Boston Spa School"
   ],
   "2398-has-accredited-body": "Another organisation",
-  "2398-accredited-body": "Gorse Scitt",
+  "2398-accredited-body": "Gorse SCITT",
   "2398-vacancies-flag": "Yes",
   "2398-vacancies-choice": "There are some vacancies",
   "2398-full-time-and-part-time": false,
@@ -576,7 +576,7 @@
     "Boston Spa School"
   ],
   "2399-has-accredited-body": "Another organisation",
-  "2399-accredited-body": "Gorse Scitt",
+  "2399-accredited-body": "Gorse SCITT",
   "2399-vacancies-flag": "Yes",
   "2399-vacancies-choice": "There are some vacancies",
   "2399-full-time-and-part-time": false,
@@ -625,7 +625,7 @@
     "Boston Spa School"
   ],
   "239C-has-accredited-body": "Another organisation",
-  "239C-accredited-body": "Gorse Scitt",
+  "239C-accredited-body": "Gorse SCITT",
   "239C-vacancies-flag": "Yes",
   "239C-vacancies-choice": "There are some vacancies",
   "239C-full-time-and-part-time": false,
@@ -675,7 +675,7 @@
     "Boston Spa School"
   ],
   "239F-has-accredited-body": "Another organisation",
-  "239F-accredited-body": "Gorse Scitt",
+  "239F-accredited-body": "Gorse SCITT",
   "239F-vacancies-flag": "Yes",
   "239F-vacancies-choice": "There are some vacancies",
   "239F-full-time-and-part-time": false,
@@ -724,7 +724,7 @@
     "Boston Spa School"
   ],
   "239D-has-accredited-body": "Another organisation",
-  "239D-accredited-body": "Gorse Scitt",
+  "239D-accredited-body": "Gorse SCITT",
   "239D-vacancies-flag": "Yes",
   "239D-vacancies-choice": "There are some vacancies",
   "239D-full-time-and-part-time": false,
@@ -772,7 +772,7 @@
     "Leeds West Academy"
   ],
   "239G-has-accredited-body": "Another organisation",
-  "239G-accredited-body": "Gorse Scitt",
+  "239G-accredited-body": "Gorse SCITT",
   "239G-vacancies-flag": "Yes",
   "239G-vacancies-choice": "There are some vacancies",
   "239G-full-time-and-part-time": false,
@@ -819,7 +819,7 @@
     "Boston Spa School"
   ],
   "239K-has-accredited-body": "Another organisation",
-  "239K-accredited-body": "Gorse Scitt",
+  "239K-accredited-body": "Gorse SCITT",
   "239K-vacancies-flag": "Yes",
   "239K-vacancies-choice": "There are some vacancies",
   "239K-full-time-and-part-time": false,
@@ -867,7 +867,7 @@
     "Leeds City Academy"
   ],
   "239L-has-accredited-body": "Another organisation",
-  "239L-accredited-body": "Gorse Scitt",
+  "239L-accredited-body": "Gorse SCITT",
   "239L-vacancies-flag": "Yes",
   "239L-vacancies-choice": "There are some vacancies",
   "239L-full-time-and-part-time": false,
@@ -910,7 +910,7 @@
     "Whitcliffe Mount School"
   ],
   "23B3-has-accredited-body": "Another organisation",
-  "23B3-accredited-body": "Gorse Scitt",
+  "23B3-accredited-body": "Gorse SCITT",
   "23B3-vacancies-flag": "Yes",
   "23B3-vacancies-choice": "There are some vacancies",
   "23B3-full-time-and-part-time": false,
@@ -949,7 +949,7 @@
     "Leeds West Academy"
   ],
   "2FL4-has-accredited-body": "Another organisation",
-  "2FL4-accredited-body": "Gorse Scitt",
+  "2FL4-accredited-body": "Gorse SCITT",
   "2FL4-vacancies-flag": "Yes",
   "2FL4-vacancies-choice": "There are some vacancies",
   "2FL4-full-time-and-part-time": false,
@@ -962,7 +962,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Art / art & design"
@@ -1029,7 +1029,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Biology"
@@ -1096,7 +1096,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Business education"
@@ -1148,7 +1148,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Chemistry"
@@ -1247,7 +1247,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Computer studies"
@@ -1304,7 +1304,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Design and technology"
@@ -1366,7 +1366,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Drama and theatre studies"
@@ -1413,7 +1413,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "English"
@@ -1490,7 +1490,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Geography"
@@ -1557,7 +1557,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "History"
@@ -1629,7 +1629,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Mathematics"
@@ -1706,7 +1706,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": [
 
       ],
@@ -1770,7 +1770,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Music"
@@ -1827,7 +1827,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Physical education"
@@ -1899,7 +1899,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Physics"
@@ -1961,7 +1961,7 @@
     {
       "level": "Primary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
 
@@ -2008,7 +2008,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Religious education"
@@ -2055,7 +2055,7 @@
     {
       "level": "Secondary",
       "sen": false,
-      "accrediting": "Gorse Scitt",
+      "accrediting": "Gorse SCITT",
       "languages": null,
       "subjects": [
         "Social science"
@@ -2330,16 +2330,6 @@
       "slug": "gorse-scitt",
       "subjects": [
         {
-          "name": "Classics",
-          "slug": "classics"
-        }
-      ]
-    },
-    {
-      "name": "Gorse Scitt",
-      "slug": "gorse-scitt",
-      "subjects": [
-        {
           "name": "Art and Design",
           "slug": "art-and-design"
         },
@@ -2415,7 +2405,6 @@
     }
   ],
   "providers": [
-
   ],
   "self_accrediting": false,
   "subjects": [
@@ -2665,7 +2654,7 @@
       "name": "Goldsmiths, University of London"
     },
     {
-      "name": "Gorse Scitt"
+      "name": "Gorse SCITT"
     },
     {
       "name": "Harris ITE"


### PR DESCRIPTION
For some reason the prototype data contains both Gorse Scitt and Gorse SCITT - which meant that the list of courses was showing twice.