### PR TITLE
Bugfix: Gorse SCITT is self-accrediting

### DIFF
--- a/app/data/prototype-data.json
+++ b/app/data/prototype-data.json
@@ -2408,7 +2408,7 @@
   ],
   "providers": [
   ],
-  "self_accrediting": false,
+  "self_accrediting": true,
   "subjects": [
     {
       "name": "Art and Design",


### PR DESCRIPTION
Fixes this bug in the prototype setup, where there are two "About" rows

<img width="686" alt="Screenshot 2021-05-13 at 10 00 48" src="https://user-images.githubusercontent.com/30665/118103708-1a427880-b3d2-11eb-89b3-1a56dc9e00b3.png">
