### PR TITLE
Add optional free text field for equivalency test details

### DIFF
--- a/app/views/course/gcses-pending-or-equivalency-tests.html
+++ b/app/views/course/gcses-pending-or-equivalency-tests.html
@@ -39,16 +39,8 @@
 
 
     {% set equivalencySubjects %}
-      {% set equivalencySubjectsName = course.programmeCode + "-equivalency-subjects" %}
-      {{ govukCheckboxes({
-        name: equivalencySubjectsName,
-        fieldset: {
-          legend: {
-            text: "Which subjects can you offer equivalency tests in?",
-            classes: "govuk-fieldset__legend--s"
-          }
-        },
-        items: [
+
+      {% set equivalencyItems = [
           {
             value: "English",
             text: "English",
@@ -58,13 +50,27 @@
             value: "maths",
             text: "Maths",
             checked: checked(equivalencySubjectsName, "maths")
-          },
-          {
+          }
+      ] %}
+
+      {% if course.subject == "Primary" %}
+        {% set equivalencyItems = equivalencyItems | push({
             value: "science",
             text: "Science",
             checked: checked(equivalencySubjectsName, "science")
+          }) %}
+      {% endif %}
+
+      {% set equivalencySubjectsName = course.programmeCode + "-equivalency-subjects" %}
+      {{ govukCheckboxes({
+        name: equivalencySubjectsName,
+        fieldset: {
+          legend: {
+            text: "Which subjects can you offer equivalency tests in?",
+            classes: "govuk-fieldset__legend--s"
           }
-        ]
+        },
+        items: equivalencyItems
       }) }}
 
       {% from "govuk/components/textarea/macro.njk" import govukTextarea %}

--- a/app/views/course/gcses-pending-or-equivalency-tests.html
+++ b/app/views/course/gcses-pending-or-equivalency-tests.html
@@ -17,7 +17,7 @@
         name: pendingGcsesRadioName,
         fieldset: {
           legend: {
-            text: "Will you accept candidates with pending GCSEs?",
+            text: "Will you consider candidates with pending GCSEs?",
             classes: "govuk-fieldset__legend--m"
           }
         },
@@ -90,7 +90,7 @@
         name: equivalencyTestsRadioName,
         fieldset: {
           legend: {
-            text: "Will you accept candidates who need to take an equivalency test in English, maths or science?",
+            text: "Will you consider candidates who need to take an equivalency test in English, maths or science?",
             classes: "govuk-fieldset__legend--m"
           }
         },

--- a/app/views/course/gcses-pending-or-equivalency-tests.html
+++ b/app/views/course/gcses-pending-or-equivalency-tests.html
@@ -66,6 +66,22 @@
           }
         ]
       }) }}
+
+      {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+      {{ govukTextarea({
+        name: course.programmeCode + "-equivalency-test-details",
+        id: "more-detail",
+        label: {
+          text: "Details about equivalency tests you offer (optional)",
+          classes: "govuk-label--s",
+          isPageHeading: false
+        },
+        value: data[course.programmeCode + "-equivalency-test-details"],
+        hint: {
+          text: "For example, when and how you offer equivalency tests, or if there are any costs that candidates need to pay."
+        }
+      }) }}
     {% endset %}
 
 

--- a/app/views/course/gcses-pending-or-equivalency-tests.html
+++ b/app/views/course/gcses-pending-or-equivalency-tests.html
@@ -22,7 +22,7 @@
           }
         },
         hint: {
-          text: "These are candidates who expect to have the qualification before the beginning of the course. If successful they would receive a conditional offer."
+          text: "These are candidates who expect to have the qualification before the beginning of the course. You can give them an offer, on the condition that they pass their GCSEs."
         },
         items: [{
           value: "true",

--- a/app/views/course/index.html
+++ b/app/views/course/index.html
@@ -394,6 +394,9 @@
               {% endif %}
             </p>
 
+            {% if equivalencyTestsOffered == "true" and data[code + "-equivalency-test-details"] %}
+              <p class="govuk-body">{{ data[code + "-equivalency-test-details"] }}</p>
+            {% endif %}
 
           {% else %}
             <div class="app-summary-list__message">


### PR DESCRIPTION
This might help providers to explain how equivalency tests work for them.

## Screenshot

![screenshot-localhost_3000-2021 06 03-15_37_24](https://user-images.githubusercontent.com/30665/120663127-abf94f00-c481-11eb-807a-feda8998d679.png)
