### PR TITLE
Content changes locations

### DIFF
--- a/app/views/cycles.html
+++ b/app/views/cycles.html
@@ -22,8 +22,8 @@
 
         <p>Use this section to:</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>manage courses in the current cycle</li>
-          <li>edit locations and vacancies in the current cycle</li>
+          <li>manage your existing courses</li>
+          <li>edit locations and vacancies</li>
         </ul>
       </div>
       <div class="govuk-!-margin-bottom-8">
@@ -33,7 +33,7 @@
         <p>Use this section to:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>prepare courses for the next cycle</li>
-          <li>manage locations needed for the next cycle</li>
+          <li>manage locations</li>
         </ul>
       </div>
     </div>

--- a/app/views/location/index.html
+++ b/app/views/location/index.html
@@ -16,7 +16,7 @@
         value: school.name,
         label: {
           classes: "govuk-label--m",
-          text: "Name"
+          text: "Location name"
         }
       }) }}
 
@@ -26,10 +26,10 @@
         value: school.urn,
         label: {
           classes: "govuk-label--m",
-          text: "Unique Reference Number (URN)"
+          text: "Unique reference number (URN)"
         },
         hint: {
-          html: "You can find URNs on <a href=\"https://www.get-information-schools.service.gov.uk/\" target=\"_blank\">Get information about schools (opens in new tab)</a>."
+          html: "<a href=\"https://www.get-information-schools.service.gov.uk/\" target=\"_blank\">Find URNs (opens in new tab)</a>."
         },
         classes: "govuk-input--width-5"
       }) }}

--- a/app/views/locations/add.html
+++ b/app/views/locations/add.html
@@ -17,7 +17,7 @@
         },
         items: [{
           value: "upload",
-          text: "Upload a list of Unique reference numbers (URNs)",
+          text: "Upload a list of unique reference numbers (URNs)",
           checked: checked(("add-placements-answer"), "upload")
         }, {
           value: "add",

--- a/app/views/locations/index.html
+++ b/app/views/locations/index.html
@@ -69,25 +69,25 @@
   </h1>
 
   <div class="govuk-!-width-two-thirds">
-    <p class="govuk-body-l">Most candidates search for courses by location. Adding locations improves the visibility of your courses on Find.</p>
+    <p class="govuk-body-l">Most candidates search for courses by location. Add your locations to improve the visibility of your courses on Find.</p>
   </div>
 
   {% set placementSchoolsHtml %}
     <h2 class="govuk-heading-l">Placement schools</h2>
-    <p class="govuk-body">A placement school is a location where candidates may be placed during their training.</p>
+    <p class="govuk-body">Add the schools where candidates may be placed.</p>
 
     {% if data["placements-display"] and schoolLocations.length > 0 %}
       <div class="govuk-!-width-two-thirds">
         <div class="govuk-inset-text">
           <h3 class="govuk-heading-m">
             {% if data["placements-display"] == "list" %}
-              Courses show a list of placement schools{{ ", and candidates select one when they apply" if data["placements-policy"] == "hosted" }}
+              Courses show precise placement locations{{ ", and candidates select one when they apply" if data["placements-policy"] == "hosted" }}
             {% else %}
               Courses show areas where placements can be offered
             {% endif %}
           </h3>
           {% if data["placements-display"] == "list" %}
-            <p class="govuk-body">Assign placement schools from the ‘Basic details’ tab on a course page.</p>
+            <p class="govuk-body">You can assign your placement schools to your courses from your individual course pages.</p>
           {% else %}
             <p class="govuk-body">Based on the school locations you have added, courses will show the following areas:</p>
             <div class="app-status-box">
@@ -109,10 +109,10 @@
       </div>
     {% else %}
       <div class="govuk-!-width-two-thirds">
-        <p class="govuk-body">Before adding placement schools, you can decide:</p>
+        <p class="govuk-body">You can choose whether to:</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>whether to show individual addresses or only the areas schools are located</li>
-          <li>if candidates can select a school when making an application</li>
+          <li>show precise placement locations or only the general area</li>
+          <li>allow candidates to choose a placement school</li>
         </ul>
 
         {{ govukButton({
@@ -125,7 +125,7 @@
 
   {% set trainingCentresHtml %}
     <h2 class="govuk-heading-l">Training centres</h2>
-    <p class="govuk-body">A training centre is a location where academic or ‘centre-based’ training takes place.</p>
+    <p class="govuk-body">Add the locations where academic or ‘centre-based’ training takes place.</p>
 
     {% if centerLocations.length > 0 %}
       {{ locationsTable(centerLocations, "Training centre") }}

--- a/app/views/locations/placements-display.html
+++ b/app/views/locations/placements-display.html
@@ -17,17 +17,17 @@
         },
         items: [{
           value: "list",
-          text: "Show a list of placement schools for each course",
+          text: "Show precise placement locations for each course",
           checked: checked(("placements-display"), "list"),
           hint: {
-            text: "You can assign placement schools from the ‘Basic details’ tab on the course page."
+            text: "You can assign your placement schools to your courses later from your individual course pages."
           }
         }, {
           value: "area",
-          text: "Show the areas where placements can be offered",
+          text: "Show only the general placement areas",
           checked: checked(("placements-display"), "area"),
           hint: {
-            text: "These areas will be generated from the placement schools locations added."
+            text: "You still need to add precise locations to generate these areas."
           }
         }]
       }) }}

--- a/app/views/locations/placements-policy.html
+++ b/app/views/locations/placements-policy.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% set title = "Can candidates choose a school when they apply?" %}
+{% set title = "Can candidates choose a placement school when they apply?" %}
 {% set backLink = paths.back %}
 
 {% block content %}

--- a/app/views/locations/upload.html
+++ b/app/views/locations/upload.html
@@ -10,8 +10,11 @@
         {{ title }}
       </h1>
 
-      <p class="govuk-body">Add multiple locations by providing a CSV of Unique reference numbers (URNs). You can review the details of each school before adding them to your account.</p>
-      <p class="govuk-body">Download this <a class="govuk-link" href="upload-template.csv" type="text/csv" download="upload-template.csv">CSV template</a> to get started.</p>
+      <p class="govuk-body">Add multiple locations by uploading a file containing school unique reference numbers (URNs).</p>
+
+      <p class="govuk-body"><a class="govuk-link" href="upload-template.csv" type="text/csv" download="upload-template.csv">Download, fill in and upload this template as a CSV file</a>.</p>
+
+      <p class="govuk-body">You'll then be able to review the locations before confirming them.</p>
 
       {{ govukFileUpload({
         id: "file-upload",

--- a/app/views/organisation/index.html
+++ b/app/views/organisation/index.html
@@ -32,7 +32,7 @@
     <div class="govuk-grid-column-two-thirds">
       {% if data["rolled-over"] %}
         {% if data["next-cycle"] %}
-          <p class="govuk-body-l">Prepare your courses and locations for the next cycle. All your courses, locations and details have been copied from the current cycle.</p>
+          <p class="govuk-body-l">Prepare your courses and locations for the next cycle. Your records have been copied from the current cycle.</p>
           <hr class="govuk-section-break govuk-section-break--m">
         {% else %}
           <p class="govuk-body-l">Manage courses, locations and vacancies in the current&nbsp;cycle.</p>

--- a/app/views/organisation/notification-enabled.html
+++ b/app/views/organisation/notification-enabled.html
@@ -32,7 +32,7 @@
     <div class="govuk-grid-column-two-thirds">
       {% if data["rolled-over"] %}
         {% if data["next-cycle"] %}
-          <p class="govuk-body-l">Prepare your courses and locations for the next cycle. All your courses, locations and details have been copied from the current cycle.</p>
+          <p class="govuk-body-l">Prepare your courses and locations for the next cycle. Your records have been copied from the current cycle.</p>
           <hr class="govuk-section-break govuk-section-break--m">
         {% else %}
           <p class="govuk-body-l">Manage courses, locations and vacancies in the current&nbsp;cycle.</p>


### PR DESCRIPTION
- remove some repetition of 'current cycle', 'next cycle' etc.
- make definitions of 'placement schools' and 'training centres' into actions 
- make the choice between showing 'precise locations' and 'general areas' really clear by using these terms