### PR TITLE
Update GCSE equivalency testing wording

### DIFF
--- a/app/views/course/gcses-pending-or-equivalency-tests.html
+++ b/app/views/course/gcses-pending-or-equivalency-tests.html
@@ -66,7 +66,7 @@
         name: equivalencySubjectsName,
         fieldset: {
           legend: {
-            text: "Which subjects can you offer equivalency tests in?",
+            text: "Which subjects will you accept equivalency tests in?",
             classes: "govuk-fieldset__legend--s"
           }
         },
@@ -79,13 +79,13 @@
         name: course.programmeCode + "-equivalency-test-details",
         id: "more-detail",
         label: {
-          text: "Details about equivalency tests you offer (optional)",
+          text: "Details about equivalency tests you offer or accept",
           classes: "govuk-label--s",
           isPageHeading: false
         },
         value: data[course.programmeCode + "-equivalency-test-details"],
         hint: {
-          text: "For example, when and how you offer equivalency tests, or if there are any costs that candidates need to pay."
+          text: "For example, whether you run the tests directly or use a third party, and if there are any costs that candidates need to pay."
         }
       }) }}
     {% endset %}


### PR DESCRIPTION
Testing showed that some providers were reluctant to tick the subject boxes as they didn't run the equivalency tests themselves, but instead required candidates to use a third party.

This tweaked wording hopefully is generic enough to cover both cases, and the free text field uses the hint text to encourage providers to explain how they offer or require the tests to be taken. This is also now non-optional.

## Before

![Before](https://user-images.githubusercontent.com/30665/121660735-6c42f080-ca9b-11eb-91ae-3c396014005f.png)

## After

![After](https://user-images.githubusercontent.com/30665/121660764-72d16800-ca9b-11eb-873d-136a4ecb8e89.png)
