### PR TITLE
Update to equivalency test status

### DIFF
--- a/app/views/course/index.html
+++ b/app/views/course/index.html
@@ -389,9 +389,9 @@
 
             <p class="govuk-body">
               {% if equivalencyTestsOffered == "true" %}
-                Equivalency tests will be offered in {{ data[code + "-equivalency-subjects"] | formatList }}
+                Equivalency tests will be accepted in {{ data[code + "-equivalency-subjects"] | formatList }}
               {% else %}
-                Equivalency tests will not be offered
+                Equivalency tests will not be accepted
               {% endif %}
             </p>
 


### PR DESCRIPTION
Replaced 'offered' with 'accepted', as some providers accept but do not offer equivalency tests.