### PR TITLE
Changed 'offered' to 'accepted' on preview page

### DIFF
--- a/app/views/preview.html
+++ b/app/views/preview.html
@@ -239,9 +239,9 @@
 
             <p class="govuk-body">
               {% if equivalencyTestsOffered == "true" %}
-                Equivalency tests will be offered in {{ data[code + "-equivalency-subjects"] | formatList }}.
+                Equivalency tests will be accepted in {{ data[code + "-equivalency-subjects"] | formatList }}.
               {% else %}
-                Equivalency tests will not be offered.
+                Equivalency tests will not be accepted.
               {% endif %}
             </p>
 


### PR DESCRIPTION
Changed equivalency test status message from 'Equivalency tests offered' to 'Equivalency tests accepted' on preview.html page.