### PR TITLE
Content edits to Prepare for next cycle page

### DIFF
--- a/app/views/rolled-over.html
+++ b/app/views/rolled-over.html
@@ -11,30 +11,25 @@
         Prepare for the next cycle
       </h1>
 
-      <p>Your courses, locations and details have been copied.</p>
+      <p>Courses for the next cycle (2022 to 2023) will be published on 1 September 2021.</p>
 
-      <p>Courses for the next cycle will be published on 1 September 2021.</p>
+      <p>Your courses, locations and organisation details have been copied from the current cycle.</p>
 
-      <p>Before then, you can:</p>
+<h2 class="govuk-heading-m">What you need to do</h2>
+
+      <p>Before you can publish courses for the next cycle, you'll need to confirm:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>add new courses</li>
-        <li>delete courses</li>
-        <li>edit the details of your courses</li>
-      </ul>
-
-      <h2 class="govuk-heading-m">New for the 2022 to 2023 cycle</h2>
-
-      <p>All applications will be made via Apply for teaching training, not UCAS.</p>
-
-      <p>You will need to confirm:</p>
-
-      <ol class="govuk-list govuk-list--number">
         <li>degree requirements</li>
         <li>GCSE requirements</li>
-        <li>whether you can sponsor visas</li>
+        <li>if you can sponsor visas</li>
         <li>locations of school placements</li>
-      </ol>
+      </ul>
+
+<p>You can also add, edit or delete courses.</p>
+
+
+
 
       <hr class="govuk-section-break govuk-section-break--m" />
 

--- a/app/views/rolled-over.html
+++ b/app/views/rolled-over.html
@@ -11,7 +11,7 @@
         Prepare for the next cycle
       </h1>
 
-      <p>Courses for the next cycle (2022 to 2023) will be published on 1 September 2021.</p>
+      <p>Courses for the next cycle (2022 to 2023) will be published on 1&nbsp;September&nbsp;2021.</p>
 
       <p>Your courses, locations and organisation details have been copied from the current cycle.</p>
 


### PR DESCRIPTION
- made the intro a bit clearer
- changed the subheading to match the link in the call-to-action which appears on right hand side of university page
- made the bottom list a bulleted list instead of numbers (in line with GOV.UK style guide)