### PR TITLE
Content change to Skilled Worker visa answer

### DIFF
--- a/app/views/about-your-organisation/visa-sponsorship.html
+++ b/app/views/about-your-organisation/visa-sponsorship.html
@@ -52,7 +52,7 @@
           checked: (data[skilledWorkerVisaRadioName] === "true")
         }, {
           value: "false",
-          text: "No",
+          text: "No, or not applicable",
           checked: (data[skilledWorkerVisaRadioName] === "false")
         }]
       }) }}


### PR DESCRIPTION
Changed the "No" answer to "No, or not applicable" for providers who don't have salaried courses.

This change needs to be made to Publish in prod alongside the Visa sponsorship, degree requirements and GCSE/equivalency test changes. 

This change is in response to the UR findings. We discussed this in the Dev/Design session 30/6/21. 