### PR TITLE
Update visa sponsorship questions

### DIFF
--- a/app/views/about-your-organisation/visa-sponsorship.html
+++ b/app/views/about-your-organisation/visa-sponsorship.html
@@ -10,9 +10,9 @@
         {{ title }}
       </h1>
 
-      <p class="govuk-bodu">Check the <a href="https://www.gov.uk/government/publications/register-of-licensed-sponsors-students" class="govuk-link">Register of Student sponsors</a> and <a href="https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers" class="govuk-link">Register of Worker and Temporary Worker licensed sponsors</a> if you’re unsure if your courses can sponsor visas.</p>
+      <p class="govuk-bodu">If you’re unsure if your courses can sponsor visas, check the <a href="https://www.gov.uk/government/publications/register-of-licensed-sponsors-students" class="govuk-link">Register of Student sponsors</a> and <a href="https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers" class="govuk-link">Register of Worker and Temporary Worker licensed sponsors</a>.</p>
 
-      <p>For more information sponsoring Student or Skilled Worker visas, see the guidance on <a href="https://www.gov.uk/guidance/recruit-trainee-teachers-from-overseas-accredited-itt-providers#recruit-by-becoming-a-visa-sponsor" class="govuk-link">Recruiting  trainee teachers from overseas: accredited ITT providers</a>.</p>
+      <p class="govuk-body">Find out how to <a href="https://www.gov.uk/guidance/recruit-trainee-teachers-from-overseas-accredited-itt-providers#recruit-by-becoming-a-visa-sponsor" class="govuk-link">become a visa sponsor</a>.</p>
 
       {% set studentVisaRadioName = "canSponsorStudentVisa" %}
       {% set skilledWorkerVisaRadioName = "canSponsorSkilledWorkerVisa" %}

--- a/app/views/about-your-organisation/visa-sponsorship.html
+++ b/app/views/about-your-organisation/visa-sponsorship.html
@@ -10,6 +10,10 @@
         {{ title }}
       </h1>
 
+      <p class="govuk-bodu">Check the <a href="https://www.gov.uk/government/publications/register-of-licensed-sponsors-students" class="govuk-link">Register of Student sponsors</a> and <a href="https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers" class="govuk-link">Register of Worker and Temporary Worker licensed sponsors</a> if you’re unsure if your courses can sponsor visas.</p>
+
+      <p>For more information sponsoring Student or Skilled Worker visas, see the guidance on <a href="https://www.gov.uk/guidance/recruit-trainee-teachers-from-overseas-accredited-itt-providers#recruit-by-becoming-a-visa-sponsor" class="govuk-link">Recruiting  trainee teachers from overseas: accredited ITT providers</a>.</p>
+
       {% set studentVisaRadioName = "canSponsorStudentVisa" %}
       {% set skilledWorkerVisaRadioName = "canSponsorSkilledWorkerVisa" %}
 
@@ -17,12 +21,9 @@
         name: studentVisaRadioName,
         fieldset: {
           legend: {
-            text: "Can you sponsor Student visas?",
+            text: "Can candidates get a sponsored Student visa for your fee-paying courses?",
             classes: "govuk-fieldset__legend--m"
           }
-        },
-        hint: {
-          text: "Applies to fee-paying courses"
         },
         items: [{
           value: "true",
@@ -39,17 +40,18 @@
         name: skilledWorkerVisaRadioName,
         fieldset: {
           legend: {
-            text: "Can you sponsor Skilled Worker visas?",
+            text: "Can candidates get a sponsored Skilled Worker visa for your salaried courses?",
             classes: "govuk-fieldset__legend--m"
           }
-        },
-        hint: {
-          text: "Applies to salaried courses"
         },
         items: [{
           value: "true",
           text: "Yes",
           checked: (data[skilledWorkerVisaRadioName] === "true")
+        }, {
+          value: "some",
+          text: "Only for some salaried courses",
+          checked: (data[skilledWorkerVisaRadioName] === "some")
         }, {
           value: "false",
           text: "No, or not applicable",


### PR DESCRIPTION
This adds some more guidance, and changes the question wording.

For Skilled Worker visas, a "Only for some salaried courses" option has been added.

These changes are because we have learnt that, for Skilled Worker visas, these need to be sponsored by the employer, who in some cases will be different from the provider (in say, a teaching partnership). This means that it is possible that only some courses are able to sponsor visas. It could even be the case that within a single course, only some of the possible school placements are able to sponsor visas.

If the "Only for some salaried courses" option was selected, then we would have to make the guidance on the course page more equivocal, perhaps suggesting candidates get in touch with the provider to check before applying.

In future, if a provider selected this option, we could potentially allow them to say which courses can sponsor Skilled Worker visas at a course level (or school placement level).

For student visas, we understand that the visa sponsoring licence has to be held by the QTS-accrediting body, which isn't necessarily the provider – however this is apparently a bit of a grey area...

## Screenshots

### Before

![Before](https://user-images.githubusercontent.com/30665/131120993-9789e129-b7eb-48ff-b67a-aa62df876bc8.png)

### After

![After](https://user-images.githubusercontent.com/30665/131121006-ba3caf9e-6856-403f-8103-a25b0a8ae62c.png)
