### PR TITLE
Various fixes to the guidance pages

### DIFF
--- a/app/content/course-summary-examples.md
+++ b/app/content/course-summary-examples.md
@@ -34,4 +34,4 @@ At the end of the course, the e-portfolio you’ll have comprised throughout the
 
 (144 words)
 
-[View more guidance on writing course summary descriptions](/guidance/writing-descriptions-for-publish-teacher-training-courses)
+[View more guidance on writing course summary descriptions](/how-to-use-this-service/writing-descriptions-for-publish-teacher-training-courses)

--- a/app/content/writing-descriptions-for-publish-teacher-training-courses.md
+++ b/app/content/writing-descriptions-for-publish-teacher-training-courses.md
@@ -26,6 +26,6 @@ It’s important to format content to make it easy to scan and write it in plain
 - avoiding jargon and using common words
 - using as few words as possible
 
-On Find postgraduate teacher training, the 'Course summary' is the first description candidates will read. See our [examples of course summaries](/guidance/course-summary-examples) that follow best practice for online content.
+On Find postgraduate teacher training, the 'Course summary' is the first description candidates will read. See our [examples of course summaries](/how-to-use-this-service/course-summary-examples) that follow best practice for online content.
 
 Read more about [how to write for the web](https://www.gov.uk/guidance/content-design/writing-for-gov-uk).

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -981,7 +981,7 @@ exports.edit_course_start_date_post = (req, res) => {
 
 exports.edit_about_course_get = (req, res) => {
   const course = courseModel.findOne({ organisationId: req.params.organisationId, courseId: req.params.courseId })
-  const wordCount = 200
+  const wordCount = 400
 
   res.render('../views/courses/about-course', {
     course,
@@ -998,7 +998,7 @@ exports.edit_about_course_post = (req, res) => {
   const course = courseModel.findOne({ organisationId: req.params.organisationId, courseId: req.params.courseId })
   course.aboutCourse = req.session.data.course.aboutCourse
 
-  const wordCount = 200
+  const wordCount = 400
 
   const errors = []
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -366,9 +366,9 @@ router.get('/', checkIsAuthenticated, (req, res) => {
 /// GUIDANCE ROUTES
 /// ------------------------------------------------------------------------ ///
 
-router.get('/guidance/:fileName', guidanceController.guidance)
+router.get('/how-to-use-this-service/:fileName', guidanceController.guidance)
 
-router.get('/guidance', guidanceController.guidance)
+router.get('/how-to-use-this-service', guidanceController.guidance)
 
 /// ------------------------------------------------------------------------ ///
 /// PROTOTYPE ADMIN

--- a/app/views/_includes/footer.njk
+++ b/app/views/_includes/footer.njk
@@ -21,11 +21,6 @@
       <p class="govuk-!-font-size-16">You’ll get a response within 5 working days, or one working day for urgent requests.</p>
       <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
         <li>
-          <a class="govuk-footer__link" href="#">
-            How to publish teacher training courses
-          </a>
-        </li>
-        <li>
           <a class="govuk-footer__link" href="https://api.publish-teacher-training-courses.service.gov.uk">
             Teacher Training Courses API documentation
           </a>

--- a/app/views/_includes/footer.njk
+++ b/app/views/_includes/footer.njk
@@ -37,7 +37,7 @@
     title: "Get help",
     html: helpHtml,
     items: [{
-      href: "/guidance",
+      href: "/how-to-use-this-service",
       text: "How to use this service"
     }, {
       href: "#",

--- a/app/views/courses/about-course.njk
+++ b/app/views/courses/about-course.njk
@@ -91,11 +91,6 @@
 
         {% endif %} #}
 
-        {{ govukInsetText({
-          text: "The first 50 words of your course summary will be shown on the search results page on Find."
-        }) }}
-
-
         {{ govukButton({
           text: "Update course summary"
         }) }}
@@ -106,10 +101,6 @@
         <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
       </p>
 
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      {# {% include "./_sidebar-markdown-help.njk" %} #}
     </div>
   </div>
 

--- a/app/views/courses/about-course.njk
+++ b/app/views/courses/about-course.njk
@@ -46,7 +46,7 @@
           <li>spell out acronyms the first time you use them, for example, ITT, NQT, SCITT</li>
         </ul>
 
-        <p class="govuk-body"><a class="govuk-link" href="/guidance/course-summary-examples">View more guidance and course summary examples</a></p>
+        <p class="govuk-body"><a class="govuk-link" href="/how-to-use-this-service/course-summary-examples">View more guidance and course summary examples</a></p>
       {% endset %}
 
       <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>

--- a/app/views/courses/about-course.njk
+++ b/app/views/courses/about-course.njk
@@ -60,7 +60,7 @@
           {{ govukCharacterCount({
             id: "about-course",
             name: "course[aboutCourse]",
-            rows: 10,
+            rows: 20,
             maxwords: wordCount,
             label: {
               text: title,

--- a/app/views/guidance/index.njk
+++ b/app/views/guidance/index.njk
@@ -29,7 +29,7 @@
         <ul class="govuk-list govuk-list--spaced">
           {% for link in links %}
             <li>
-              <a href="/guidance/{{ link.slug }}">{{ link.title }}</a>
+              <a href="/how-to-use-this-service/{{ link.slug }}">{{ link.title }}</a>
             </li>
           {% endfor %}
         </ul>

--- a/app/views/guidance/show.njk
+++ b/app/views/guidance/show.njk
@@ -14,7 +14,7 @@
       href: "/"
     }, {
       text: caption,
-      href: "/guidance"
+      href: "/how-to-use-this-service"
     }, {
       text: title
     }


### PR DESCRIPTION
- Change URL slug from `/guidance` to `/how-to-use-this-service`
- Remove inset text from the course summary page
- Remove 'How to publish teacher training courses' from the footer
- Change course summary word count back to 400 and row height to 20