### PR TITLE
Fix missing 'isRollover' variable

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -80,6 +80,7 @@ router.all('*', (req, res, next) => {
   res.locals.referrer = req.query.referrer
   res.locals.query = req.query
   res.locals.flash = req.flash('success') // pass through 'success' messages only
+  res.locals.isRollover = process.env.IS_ROLLOVER || 'false'
   next()
 })
 


### PR DESCRIPTION
The prototype has an environment variable called `IS_ROLLOVER`.

When the prototype was upgraded to version 13, the environment variable was no longer passed through to the view. This meant things like the cycle switcher and phase banner did not display correctly.

This PR adds a variable to the `router.js` giving views access to the variable:

```javascript
res.locals.isRollover = process.env.IS_ROLLOVER || 'false'
```